### PR TITLE
(enahnce): Add CustomNetworkImage widget 

### DIFF
--- a/lib/common/presentation/widgets/custom_network_image.dart
+++ b/lib/common/presentation/widgets/custom_network_image.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class CustomNetworkImage extends StatelessWidget {
+  final double width;
+  final double height;
+  final String imageUrl;
+  final Widget placeHolderImage;
+  final Widget errorImage;
+  final BoxFit fit;
+  const CustomNetworkImage(
+      {super.key,
+      required this.imageUrl,
+      required this.placeHolderImage,
+      required this.errorImage,
+      this.width = 50.0,
+      this.height = 50.0,
+      this.fit = BoxFit.contain});
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.network(
+      imageUrl,
+      width: width,
+      height: height,
+      fit: fit,
+      matchTextDirection: true,
+      errorBuilder: (context, error, stackTrace) {
+        return errorImage;
+      },
+      loadingBuilder: (context, child, loadingProgress) {
+        if (loadingProgress == null) return child;
+        return placeHolderImage;
+      },
+    );
+  }
+}

--- a/lib/home/presentation/widgets/row_types.dart
+++ b/lib/home/presentation/widgets/row_types.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:icheja_mobile/common/presentation/theme/color_theme.dart';
+import 'package:icheja_mobile/common/presentation/widgets/custom_network_image.dart';
 
 class RowTypes extends StatelessWidget {
   final String text;
@@ -56,12 +57,12 @@ class RowTypes extends StatelessWidget {
           const SizedBox(width: 18.0),
           Expanded(
             flex: 3,
-            child: Image.network(
-              imageUrl,
+            child: CustomNetworkImage(
+              imageUrl: imageUrl,
+              placeHolderImage: const CircularProgressIndicator(),
+              errorImage: const Icon(Icons.error, size: 50.0),
               width: 50.0,
               height: 50.0,
-              fit: BoxFit.contain,
-              matchTextDirection: true,
             ),
           ),
         ],


### PR DESCRIPTION
This pull request introduces a new reusable `CustomNetworkImage` widget to simplify and enhance image handling across the application. It replaces direct usage of `Image.network` in the `RowTypes` widget with the new custom widget, improving error handling and loading states.

### New reusable widget:

* [`lib/common/presentation/widgets/custom_network_image.dart`](diffhunk://#diff-04a11c10bc4040bfd7a6e10025ff90cbbf1a5d32f622d993da019bf9ed88ca2cR1-R36): Added the `CustomNetworkImage` widget, which encapsulates network image loading with customizable error and placeholder states.

### Integration of the new widget:

* [`lib/home/presentation/widgets/row_types.dart`](diffhunk://#diff-dfb695b26ecbe802266fb824926e3c0f30f888dbd61dcea98b932d5e0e9d2d2eR3): Imported the `CustomNetworkImage` widget and replaced the direct usage of `Image.network` in the `RowTypes` widget with `CustomNetworkImage`. This improves error handling and adds a loading indicator. [[1]](diffhunk://#diff-dfb695b26ecbe802266fb824926e3c0f30f888dbd61dcea98b932d5e0e9d2d2eR3) [[2]](diffhunk://#diff-dfb695b26ecbe802266fb824926e3c0f30f888dbd61dcea98b932d5e0e9d2d2eL59-L64)