### PR TITLE
feat: add family resource content to resource detail view

### DIFF
--- a/lib/resources/domain/entities/family_resource_entity.dart
+++ b/lib/resources/domain/entities/family_resource_entity.dart
@@ -1,0 +1,6 @@
+class FamilyResourceEntity {
+  final String role;
+  final String imgPath;
+
+  FamilyResourceEntity({required this.role, required this.imgPath});
+}

--- a/lib/resources/presentation/pages/resource_detail.dart
+++ b/lib/resources/presentation/pages/resource_detail.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:icheja_mobile/core/application/dependency_injection.dart';
 import 'package:icheja_mobile/resources/domain/entities/abecedary_resource_entity.dart';
+import 'package:icheja_mobile/resources/domain/entities/family_resource_entity.dart';
 import 'package:icheja_mobile/resources/presentation/layouts/resource_layout.dart';
 import 'package:icheja_mobile/resources/presentation/viewmodels/resource_detail_viewmodel.dart';
 import 'package:icheja_mobile/resources/presentation/widgets/abecedary_content.dart';
+import 'package:icheja_mobile/resources/presentation/widgets/family_content.dart';
 import 'package:provider/provider.dart';
 
 class ResourceDetail extends StatelessWidget {
@@ -26,6 +28,11 @@ class ResourceDetail extends StatelessWidget {
                     content: viewModel.resourceDetail.content
                         as List<AbecedaryResourceEntity>,
                   )
+                ] else if (viewModel.resourceDetail.content
+                    is List<FamilyResourceEntity>) ...[
+                  FamilyContet(
+                      contet: viewModel.resourceDetail.content
+                          as List<FamilyResourceEntity>)
                 ]
               ]
             ],

--- a/lib/resources/presentation/viewmodels/resource_detail_viewmodel.dart
+++ b/lib/resources/presentation/viewmodels/resource_detail_viewmodel.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:icheja_mobile/core/session/session_manager.dart';
-import 'package:icheja_mobile/resources/domain/entities/abecedary_resource_entity.dart';
+import 'package:icheja_mobile/resources/domain/entities/family_resource_entity.dart';
 import 'package:icheja_mobile/resources/domain/entities/resource_detail_entity.dart';
 
 class ResourceDetailViewmodel extends ChangeNotifier {
@@ -49,146 +49,26 @@ class ResourceDetailViewmodel extends ChangeNotifier {
   Future<void> _fetchResource() async {
     try {
       _resourceDetail = ResourceDetailEntity(
-        id: '1',
-        title: 'Abecedario',
-        content: <AbecedaryResourceEntity>[
-          AbecedaryResourceEntity(
-              vocal: 'A',
-              minusVocal: 'a',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'B',
-              minusVocal: 'b',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'C',
-              minusVocal: 'c',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'D',
-              minusVocal: 'd',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'E',
-              minusVocal: 'e',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'F',
-              minusVocal: 'f',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'G',
-              minusVocal: 'g',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'H',
-              minusVocal: 'h',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'I',
-              minusVocal: 'i',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'J',
-              minusVocal: 'j',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'K',
-              minusVocal: 'k',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'L',
-              minusVocal: 'l',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'M',
-              minusVocal: 'm',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'N',
-              minusVocal: 'n',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'Ñ',
-              minusVocal: 'ñ',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'O',
-              minusVocal: 'o',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'P',
-              minusVocal: 'p',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'Q',
-              minusVocal: 'q',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'R',
-              minusVocal: 'r',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'S',
-              minusVocal: 's',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'T',
-              minusVocal: 't',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'U',
-              minusVocal: 'u',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'V',
-              minusVocal: 'v',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'W',
-              minusVocal: 'w',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'X',
-              minusVocal: 'x',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'Y',
-              minusVocal: 'y',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-          AbecedaryResourceEntity(
-              vocal: 'Z',
-              minusVocal: 'z',
-              imageUrl:
-                  'https://res.cloudinary.com/dsiamqhuu/image/upload/v1751572924/ICHEJA/ICHEJA/T2_R1_1.svg'),
-        ],
-      );
+          id: "1",
+          title: "Familia",
+          content: <FamilyResourceEntity>[
+            FamilyResourceEntity(
+                role: "Mamá",
+                imgPath:
+                    "http://res.cloudinary.com/dsiamqhuu/image/upload/v1751579595/ICHEJA/ICHEJA/T3_R1_1"),
+            FamilyResourceEntity(
+                role: "Papá",
+                imgPath:
+                    "http://res.cloudinary.com/dsiamqhuu/image/upload/v1751579627/ICHEJA/ICHEJA/T3_R1_2"),
+            FamilyResourceEntity(
+                role: "Hermano",
+                imgPath:
+                    "http://res.cloudinary.com/dsiamqhuu/raw/upload/v1751581189/ICHEJA/ICHEJA/T3_R1_3"),
+            FamilyResourceEntity(
+                role: "Hermana",
+                imgPath:
+                    "http://res.cloudinary.com/dsiamqhuu/raw/upload/v1751581248/ICHEJA/ICHEJA/T3_R1_4"),
+          ]);
     } catch (e) {
       _error = 'Failed to load resources: $e';
     }

--- a/lib/resources/presentation/widgets/family_content.dart
+++ b/lib/resources/presentation/widgets/family_content.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:icheja_mobile/common/presentation/widgets/custom_svg_network_image.dart';
+import 'package:icheja_mobile/resources/domain/entities/family_resource_entity.dart';
+
+class FamilyContet extends StatefulWidget {
+  final List<FamilyResourceEntity> contet;
+  const FamilyContet({super.key, required this.contet});
+
+  @override
+  State<FamilyContet> createState() => _FamilyContetState();
+}
+
+class _FamilyContetState extends State<FamilyContet> {
+  PageController _pageController = PageController();
+  int _currentIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController(initialPage: 0, viewportFraction: 0.8);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.contet.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return SizedBox(
+      height: 400,
+      child: Stack(
+        children: [
+          PageView.builder(
+            controller: _pageController,
+            onPageChanged: (index) {
+              setState(() {
+                _currentIndex = index;
+              });
+            },
+            itemCount: widget.contet.length,
+            itemBuilder: (context, index) {
+              final resource = widget.contet[index];
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                child: _buildFamilyCard(resource),
+              );
+            },
+          ),
+          // Botón anterior
+          if (widget.contet.length > 1)
+            Positioned(
+              left: 0,
+              top: 0,
+              bottom: 0,
+              child: Center(
+                child: GestureDetector(
+                  onTap: () {
+                    if (_currentIndex > 0) {
+                      _pageController.previousPage(
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeInOut,
+                      );
+                    }
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.8),
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.1),
+                          blurRadius: 4,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                    child: Icon(
+                      Icons.chevron_left,
+                      size: 30,
+                      color: _currentIndex > 0 ? Colors.black : Colors.grey,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          // Botón siguiente
+          if (widget.contet.length > 1)
+            Positioned(
+              right: 0,
+              top: 0,
+              bottom: 0,
+              child: Center(
+                child: GestureDetector(
+                  onTap: () {
+                    if (_currentIndex < widget.contet.length - 1) {
+                      _pageController.nextPage(
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeInOut,
+                      );
+                    }
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(0.8),
+                      shape: BoxShape.circle,
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.1),
+                          blurRadius: 4,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                    child: Icon(
+                      Icons.chevron_right,
+                      size: 30,
+                      color: _currentIndex < widget.contet.length - 1
+                          ? Colors.black
+                          : Colors.grey,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFamilyCard(FamilyResourceEntity resource) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Color(0xFF4A90E2),
+            Color(0xFF357ABD),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.1),
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          // Título del rol
+          Padding(
+            padding: const EdgeInsets.only(top: 20, bottom: 10),
+            child: Text(
+              resource.role,
+              style: const TextStyle(
+                fontSize: 32,
+                fontWeight: FontWeight.bold,
+                color: Colors.white,
+              ),
+            ),
+          ),
+          // Imagen del personaje
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(20),
+              child: CustomSvgNetworkImage(
+                imageUrl: resource.imgPath,
+                width: MediaQuery.of(context).size.width * 0.7,
+                height: MediaQuery.of(context).size.height * 0.5,
+                errorImage: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.2),
+                    borderRadius: BorderRadius.circular(15),
+                  ),
+                  child: const Icon(
+                    Icons.person,
+                    size: 80,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature to display family-related resources in the application. It includes the addition of a new entity, updates to existing view models and pages, and the creation of a new widget to render family resource content. The most important changes are listed below.

### Entity Addition:
* Added a new `FamilyResourceEntity` class to represent family-related resources with `role` and `imgPath` properties. (`lib/resources/domain/entities/family_resource_entity.dart`)

### View Model Updates:
* Updated `ResourceDetailViewmodel` to use `FamilyResourceEntity` instead of `AbecedaryResourceEntity` and replaced the hardcoded content with family-related data. (`lib/resources/presentation/viewmodels/resource_detail_viewmodel.dart`)

### Page Updates:
* Modified `ResourceDetail` page to dynamically render `FamilyContent` when the resource content type is `FamilyResourceEntity`. (`lib/resources/presentation/pages/resource_detail.dart`)

### Widget Creation:
* Added a new `FamilyContet` widget to display family resources in a carousel format, including navigation buttons and gradient-styled cards. (`lib/resources/presentation/widgets/family_content.dart`)