### PR TITLE
(feat) writing exercise added

### DIFF
--- a/lib/exercises/presentation/widgets/exercise_content.dart
+++ b/lib/exercises/presentation/widgets/exercise_content.dart
@@ -5,6 +5,7 @@ import 'package:icheja_mobile/common/presentation/theme/color_theme.dart';
 import 'package:icheja_mobile/common/presentation/widgets/custom_container_border.dart';
 import 'package:icheja_mobile/common/presentation/widgets/custom_flottie_image.dart';
 import 'package:icheja_mobile/common/presentation/widgets/custom_svg_network_image.dart';
+import 'package:icheja_mobile/common/presentation/widgets/image_decoration_container.dart';
 import 'package:icheja_mobile/common/presentation/widgets/modal_content.dart';
 import 'package:icheja_mobile/common/presentation/widgets/modal_footer_actions.dart';
 import 'package:icheja_mobile/common/presentation/widgets/modal_header.dart';
@@ -19,6 +20,7 @@ class ExerciseContent extends StatelessWidget {
   final ExerciseViewModel viewModel;
   final bool isText;
   final bool isSelection;
+  final bool isWriting;
   // final Exercise exercise;
 
   const ExerciseContent({
@@ -27,6 +29,7 @@ class ExerciseContent extends StatelessWidget {
     required this.viewModel,
     this.isText = false,
     this.isSelection = false,
+    this.isWriting = false,
     required this.fieldNameSelected,
   });
 
@@ -128,7 +131,22 @@ class ExerciseContent extends StatelessWidget {
               exerciseCtx: viewModel.exerciseMock?.contexto ?? {},
               imagesPath: viewModel.exerciseMock?.rutasImagenes ?? [],
               viewModel: viewModel)
-        ]
+        ] else if (isWriting) ...[
+          const SizedBox(height: 16),
+          ImageDecorationContainer(
+            imageUrl: viewModel.exerciseMock?.rutasImagenes[0] ??
+                'http://res.cloudinary.com/dsiamqhuu/image/upload/v1751571141/ICHEJA/ICHEJA/T1_E1.jpg',
+            width: size.width * 0.30,
+            fit: BoxFit.contain,
+            height: size.height * 0.30,
+          ),
+          const SizedBox(height: 16),
+          WritingExerciseActions(
+              viewModel: viewModel,
+              onSendExercise: () {
+                _showGamificationModal(context);
+              }),
+        ],
 
         // ? For future use, if needed
         // ExerciseMediaDisplay(

--- a/lib/exercises/presentation/widgets/exercise_view.dart
+++ b/lib/exercises/presentation/widgets/exercise_view.dart
@@ -32,6 +32,7 @@ class ExerciseView extends StatelessWidget {
               // exercise: viewModel.currentExercise!,
               isText: viewModel.exerciseMock?.texto ?? false,
               isSelection: viewModel.exerciseMock?.seleccion ?? false,
+              isWriting: viewModel.exerciseMock?.escritura ?? false,
               fieldNameSelected: fieldNameSelected,
             ),
           )


### PR DESCRIPTION
This pull request introduces support for a new "writing" exercise type in the `ExerciseContent` and `ExerciseView` components, along with the integration of the `ImageDecorationContainer` widget for enhanced visual presentation. The changes ensure that the new exercise type is properly handled and displayed within the app.

### Support for "writing" exercise type:

* **Added `isWriting` property to `ExerciseContent` and `ExerciseView`:**
  - A new boolean property `isWriting` was added to both `ExerciseContent` and `ExerciseView` to indicate whether the current exercise is of the writing type. [[1]](diffhunk://#diff-6723eee5d5e417ae53f77911138936b37453b822737a1cdf7c5fcc96c4067284R23) [[2]](diffhunk://#diff-064cf8f5841285b09fce564581b8bc2afedf2899a9debcc6f27bc237facb61aaR35)
  - Default value for `isWriting` set to `false` in the constructor of `ExerciseContent`.

* **Conditional rendering for writing exercises in `ExerciseContent`:**
  - Added logic to render specific widgets when `isWriting` is `true`. This includes a new `ImageDecorationContainer` for displaying an image and `WritingExerciseActions` for user interactions like submitting the exercise.

### Integration of `ImageDecorationContainer`:

* **Imported `ImageDecorationContainer` widget:**
  - Added an import for `ImageDecorationContainer` in `exercise_content.dart` to enable its usage for displaying images in writing exercises.… support it